### PR TITLE
Update Get_M_one_step.h

### DIFF
--- a/pkg/src/Get_M_one_step.h
+++ b/pkg/src/Get_M_one_step.h
@@ -1,15 +1,20 @@
-double Get_M_one_step(int i1, int i2, int i3, int i4, int i5){
-double temp_sum;
-temp_sum = 0.0; // Sum up infected cells that are one mutational step away
-if (i1 == 1)  temp_sum =  temp_sum  + I[ 0][i2][i3][i4][i5]; // Mutations from sensitivity to resistance
-if (i2 == 1)  temp_sum =  temp_sum  + I[i1][ 0][i3][i4][i5];
-if (i3 == 1)  temp_sum =  temp_sum  + I[i1][i2][ 0][i4][i5];
-if (i4 == 1)  temp_sum =  temp_sum  + I[i1][i2][i3][ 0][i5];
-if (i5 == 1)  temp_sum =  temp_sum  + I[i1][i2][i3][i4][ 0];
-if (i1 == 0)  temp_sum =  temp_sum  + I[ 1][i2][i3][i4][i5]; // Back mutations from resistance to sensitivity
-if (i2 == 0)  temp_sum =  temp_sum  + I[i1][ 1][i3][i4][i5];
-if (i3 == 0)  temp_sum =  temp_sum  + I[i1][i2][ 1][i4][i5];
-if (i4 == 0)  temp_sum =  temp_sum  + I[i1][i2][i3][ 1][i5];
-if (i5 == 0)  temp_sum =  temp_sum  + I[i1][i2][i3][i4][ 1];
-return(temp_sum);
+double Get_M_one_step(long i, int i1, int i2, int i3, int i4, int i5){
+
+  double temp_sum;
+
+  temp_sum = 0.0; // Sum up infected cells that are one mutational step away
+  if (i1 == 1)  temp_sum =  temp_sum  + M_vec[i][ 0][i2][i3][i4][i5]; // Mutations from sensitivity to resistance.  Note: Earlier version incorrectly summed over I_vec!
+  if (i2 == 1)  temp_sum =  temp_sum  + M_vec[i][i1][ 0][i3][i4][i5];
+  if (i3 == 1)  temp_sum =  temp_sum  + M_vec[i][i1][i2][ 0][i4][i5];
+  if (i4 == 1)  temp_sum =  temp_sum  + M_vec[i][i1][i2][i3][ 0][i5];
+  if (i5 == 1)  temp_sum =  temp_sum  + M_vec[i][i1][i2][i3][i4][ 0];
+  
+  if (i1 == 0)  temp_sum =  temp_sum  + M_vec[i][ 1][i2][i3][i4][i5]; // Back mutations from resistance to sensitivity
+  if (i2 == 0)  temp_sum =  temp_sum  + M_vec[i][i1][ 1][i3][i4][i5];
+  if (i3 == 0)  temp_sum =  temp_sum  + M_vec[i][i1][i2][ 1][i4][i5];
+  if (i4 == 0)  temp_sum =  temp_sum  + M_vec[i][i1][i2][i3][ 1][i5];
+  if (i5 == 0)  temp_sum =  temp_sum  + M_vec[i][i1][i2][i3][i4][ 1];
+
+  return(temp_sum);
+
 }


### PR DESCRIPTION
Per John's request, I updated this C routine that "sums up over the I_vec values instead of the M_vec values". This code also speeds up the routine and "allows the computer to avoid looking for mutations that are extremely unlikely to appear".

John (@jmittler) please verify if this needs to be merged to the master.